### PR TITLE
init: Add support for kernels that don't have finit_module

### DIFF
--- a/init/Android.mk
+++ b/init/Android.mk
@@ -99,6 +99,10 @@ ifneq ($(TARGET_IGNORE_RO_BOOT_REVISION),)
 LOCAL_CFLAGS += -DIGNORE_RO_BOOT_REVISION
 endif
 
+ifeq ($(KERNEL_HAS_FINIT_MODULE), false)
+LOCAL_CFLAGS += -DNO_FINIT_MODULE
+endif
+
 LOCAL_MODULE:= init
 LOCAL_C_INCLUDES += \
     system/extras/ext4_utils \

--- a/init/builtins.cpp
+++ b/init/builtins.cpp
@@ -29,7 +29,9 @@
 #include <sys/socket.h>
 #include <sys/mount.h>
 #include <sys/resource.h>
+#ifndef NO_FINIT_MODULE
 #include <sys/syscall.h>
+#endif
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -69,20 +71,34 @@ using android::base::StringPrintf;
 #define UNMOUNT_CHECK_MS 5000
 #define UNMOUNT_CHECK_TIMES 10
 
+#ifdef NO_FINIT_MODULE
+// System call provided by bionic but not in any header file.
+extern "C" int init_module(void *, unsigned long, const char *);
+#endif
+
 static const int kTerminateServiceDelayMicroSeconds = 50000;
 
 static int insmod(const char *filename, const char *options) {
+#ifndef NO_FINIT_MODULE
     int fd = open(filename, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
     if (fd == -1) {
         ERROR("insmod: open(\"%s\") failed: %s", filename, strerror(errno));
+#else
+    std::string module;
+    if (!read_file(filename, &module)) {
+#endif
         return -1;
     }
+#ifndef NO_FINIT_MODULE
     int rc = syscall(__NR_finit_module, fd, options, 0);
     if (rc == -1) {
         ERROR("finit_module for \"%s\" failed: %s", filename, strerror(errno));
     }
     close(fd);
     return rc;
+#else
+    return init_module(&module[0], module.size(), options);
+#endif
 }
 
 static int __ifupdown(const char *interface, int up) {


### PR DESCRIPTION
Some kernels don't have finit_module, which makes booting Android 7.0
impossible if people can't backport it themselves, so set 
KERNEL_HAS_FINIT_MODULE := false in BoardConfig.mk file to
allow booting 7.0 even when the kernel doesn't have finit_
module :)

Change-Id: Iec63c1846cdc5e5bb3b61610ea438cf8eff8635b