### PR TITLE
Revert "rootdir: init.rc: Fix for "add_tid_to_cgroup failed to write"…

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -148,7 +148,6 @@ on init
     mkdir /dev/cpuctl
     mount cgroup none /dev/cpuctl cpu
     chown system system /dev/cpuctl
-    chmod 0660 /dev/cpuctl
     chown system system /dev/cpuctl/tasks
     chmod 0666 /dev/cpuctl/tasks
     write /dev/cpuctl/cpu.rt_period_us 1000000


### PR DESCRIPTION
… warnings"

Ummm, this is a directory, not a file.  This commit just removed the ability to
access this directory for anything except a root process running with dac_override
and/or dac_read_search capabilities.

drw-rw---- 3 system system 0 1970-12-12 12:17 /dev/cpuctl

This reverts commit 4fdff17b7f597eaea76c7c2ea91da38cc5f59cf8.

Change-Id: I3b30b7e2f5d67c987f53e80f5fbe0570e30e0f64