### PR TITLE
Revert "init.rc: set initial cpuset to all cores"

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -169,25 +169,25 @@ on init
     # this ensures that the cpusets are present and usable, but the device's
     # init.rc must actually set the correct cpus
     mkdir /dev/cpuset/foreground
-    copy /dev/cpuset/cpus /dev/cpuset/foreground/cpus
-    copy /dev/cpuset/mems /dev/cpuset/foreground/mems
+    write /dev/cpuset/foreground/cpus 0
+    write /dev/cpuset/foreground/mems 0
     mkdir /dev/cpuset/foreground/boost
-    copy /dev/cpuset/cpus /dev/cpuset/foreground/boost/cpus
-    copy /dev/cpuset/mems /dev/cpuset/foreground/boost/mems
+    write /dev/cpuset/foreground/boost/cpus 0
+    write /dev/cpuset/foreground/boost/mems 0
     mkdir /dev/cpuset/background
-    copy /dev/cpuset/cpus /dev/cpuset/background/cpus
-    copy /dev/cpuset/mems /dev/cpuset/background/mems
+    write /dev/cpuset/background/cpus 0
+    write /dev/cpuset/background/mems 0
 
     # system-background is for system tasks that should only run on
     # little cores, not on bigs
     # to be used only by init, so don't change system-bg permissions
     mkdir /dev/cpuset/system-background
-    copy /dev/cpuset/cpus /dev/cpuset/system-background/cpus
-    copy /dev/cpuset/mems /dev/cpuset/system-background/mems
+    write /dev/cpuset/system-background/cpus 0
+    write /dev/cpuset/system-background/mems 0
 
     mkdir /dev/cpuset/top-app
-    copy /dev/cpuset/cpus /dev/cpuset/top-app/cpus
-    copy /dev/cpuset/mems /dev/cpuset/top-app/mems
+    write /dev/cpuset/top-app/cpus 0
+    write /dev/cpuset/top-app/mems 0
 
     # change permissions for all cpusets we'll touch at runtime
     chown system system /dev/cpuset


### PR DESCRIPTION
Looks like cpusets doesn't initialize itself very sanely and this
causes all tasks to be placed in the root cgroup during boot, which
isn't what we wanted...

This reverts commit ada295f88cbcf6eff0e417abb753f1457df279c7.

Change-Id: I8d040c3e8e7a1d705c311d40f72754c999b80da7